### PR TITLE
Use correct stat name when reporting overload

### DIFF
--- a/src/riak_core_vnode_proxy.erl
+++ b/src/riak_core_vnode_proxy.erl
@@ -275,7 +275,7 @@ handle_proxy(Msg, State=#state{check_counter=Counter,
                            check_request=RequestState2}}.
 
 handle_overload(Msg, #state{mod=Mod, index=Index}) ->
-    riak_core_stat:update(dropped_vnode_requests),
+    riak_core_stat:update(dropped_vnode_requests_total),
     case Msg of
         {'$gen_event', ?VNODE_REQ{sender=Sender, request=Request}} ->
             catch(Mod:handle_overload_command(Request, Sender, Index));


### PR DESCRIPTION
Because the stat is not found due to mismatch, the following error message is encountered in the logs during an overload scenario:

```
2016-02-12 14:16:03.017 [debug] <0.428.0>@riak_core_stat:handle_cast:136 dropped_vnode_requests not found on update.
2016-02-12 14:16:03.017 [debug] <0.428.0>@riak_core_stat:handle_cast:136 dropped_vnode_requests not found on update.
2016-02-12 14:16:03.017 [debug] <0.428.0>@riak_core_stat:handle_cast:136 dropped_vnode_requests not found on update.
```
