### PR TITLE
rand module2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,6 +3,7 @@
 %{cover_enabled, true}.
 {erl_opts, [warnings_as_errors, {parse_transform, lager_transform},
             debug_info, {platform_define, "^[0-9]+", namespaced_types},
+			{platform_define, "^((1[8|9])|2)", rand_module},
             {platform_define, "^R15", "old_hash"}]}.
 {edoc_opts, [{preprocess, true}]}.
 {eunit_opts, [verbose]}.
@@ -24,7 +25,7 @@
   {riak_ensemble, "~>2.2.0", {pkg, riak_ensemble_ng}},
   {pbkdf2, "~>2.0.0"},
   {blume, "~>0.1.0"},
-  {chash, "~>0.1.1"},
+  {chash, "~>0.1.2"},
   {eleveldb, "~>2.2.19"},
   {exometer_core, "~>1.0.0", {pkg, basho_exometer_core}}
 ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,11 +1,10 @@
-{"1.1.0",
 [{<<"basho_stats">>,{pkg,<<"basho_stats">>,<<"1.0.3">>},0},
  {<<"bear">>,{pkg,<<"bear">>,<<"0.8.3">>},1},
  {<<"blume">>,{pkg,<<"blume">>,<<"0.1.0">>},0},
- {<<"chash">>,{pkg,<<"chash">>,<<"0.1.1">>},0},
+ {<<"chash">>,{pkg,<<"chash">>,<<"0.1.2">>},0},
  {<<"clique">>,{pkg,<<"clique">>,<<"0.3.6">>},0},
  {<<"cuttlefish">>,{pkg,<<"cuttlefish">>,<<"2.0.8">>},0},
- {<<"edown">>,{pkg,<<"edown">>,<<"0.7.0">>},0},
+ {<<"edown">>,{pkg,<<"edown">>,<<"0.8.1">>},2},
  {<<"eleveldb">>,{pkg,<<"eleveldb">>,<<"2.2.19">>},0},
  {<<"exometer_core">>,{pkg,<<"basho_exometer_core">>,<<"1.0.2">>},0},
  {<<"folsom">>,{pkg,<<"folsom">>,<<"0.8.3">>},0},
@@ -17,26 +16,4 @@
  {<<"poolboy">>,{pkg,<<"basho_poolboy">>,<<"0.8.1-p3">>},0},
  {<<"riak_ensemble">>,{pkg,<<"riak_ensemble_ng">>,<<"2.2.0">>},0},
  {<<"riak_sysmon">>,{pkg,<<"riak_sysmon">>,<<"2.1.3">>},0},
- {<<"setup">>,{pkg,<<"setup">>,<<"1.7.0">>},1}]}.
-[
-{pkg_hash,[
- {<<"basho_stats">>, <<"7E1174151509C64FCC1934120ED32295E14F84DAAE7F84926BA2C8D3700D146C">>},
- {<<"bear">>, <<"866002127A97932720A0D475D8582C98EC5FB78DB3A18DFE7EAF91594D9024B8">>},
- {<<"blume">>, <<"62DDA46B43E24D4B8D5407B8F6DDB78EBD2A8CDC84D9BC822CDDAEF6F402F3EB">>},
- {<<"chash">>, <<"AB209E4985C7BEDBA6E9F7B1412586A42EBCD0CB3B29CDCF2605EC605FD1A7DF">>},
- {<<"clique">>, <<"1A7EB99DF038CC3C76686A67CA41D0F5F6A2F0F5D9863FE091EB8C35600EF80F">>},
- {<<"cuttlefish">>, <<"8B2AF27EF8540FCF23CFB6C037318E5C4EBB8D12A1E44F9F932B875B14005C28">>},
- {<<"edown">>, <<"6803599606B10F8E328D6D60C44CD16244CD2429908894C415FCE4211C3BFEFD">>},
- {<<"eleveldb">>, <<"81339BEB68DA0A5CDFF8662D5F4E8089B83530A7B8238D3F63B734A4D4C8040D">>},
- {<<"exometer_core">>, <<"DC4BC9B0B47EDEE0C053B16AC5B9C692E662C7E1513FFC96F4D928BC3328D65F">>},
- {<<"folsom">>, <<"71CFF146152FA95E6092E62119F9DC96888660111E7B61853C8FDCF80598A4E0">>},
- {<<"getopt">>, <<"B17556DB683000BA50370B16C0619DF1337E7AF7ECBF7D64FBF8D1D6BCE3109B">>},
- {<<"goldrush">>, <<"2024BA375CEEA47E27EA70E14D2C483B2D8610101B4E852EF7F89163CDB6E649">>},
- {<<"lager">>, <<"EEF4E18B39E4195D37606D9088EA05BF1B745986CF8EC84F01D332456FE88D17">>},
- {<<"parse_trans">>, <<"3F5F7B402928FB9FD200C891E635DE909045D1EFAC40CE3F924D3892898F85EB">>},
- {<<"pbkdf2">>, <<"11C23279FDED5C0027AB3996CFAE77805521D7EF4BABDE2BD7EC04A9086CF499">>},
- {<<"poolboy">>, <<"EBA815CD24871C37BF0538221D3E12EE14DC015CA5DCA74696E579E53F0FF9D5">>},
- {<<"riak_ensemble">>, <<"2078B8C2D8045B05FDED98E17F2571257F8FB2059C1B9A05C2EA6AFF4D898AD5">>},
- {<<"riak_sysmon">>, <<"2E81AF5763336C0B136D7ECEFFBEC3540DB20D54459C9F2AE1275FEE4927FB7B">>},
- {<<"setup">>, <<"15DF8E57C6DF9755E22BFB1AEF0C640BD97E9889396FDFB2A85A5536A9043674">>}]}
-].
+ {<<"setup">>,{pkg,<<"setup">>,<<"1.7.0">>},1}].

--- a/src/bloom.erl
+++ b/src/bloom.erl
@@ -192,11 +192,19 @@ bitarray_get(I, A) ->
 
 simple_shuffle(L, N) ->
     lists:sublist(simple_shuffle(L), 1, N).
+-ifdef(rand_module).
+simple_shuffle(L) ->
+    N = 1000 * length(L),
+    L2 = [{rand:uniform(N), E} || E <- L],
+    {_, L3} = lists:unzip(lists:keysort(1, L2)),
+    L3.
+-else.
 simple_shuffle(L) ->
     N = 1000 * length(L),
     L2 = [{random:uniform(N), E} || E <- L],
     {_, L3} = lists:unzip(lists:keysort(1, L2)),
     L3.
+-endif.
 
 fixed_case_test_() ->
     {timeout, 100, fun() -> fixed_case(bloom(5000), 5000, 0.001) end}.

--- a/src/riak_core_claimant.erl
+++ b/src/riak_core_claimant.erl
@@ -1406,6 +1406,28 @@ rebalance_ring(_CNode, Next, _CState) ->
     Next.
 
 %% @private
+-ifdef(rand_module).
+handle_down_nodes(CState, Next) ->
+    LeavingMembers = riak_core_ring:members(CState, [leaving, invalid]),
+    DownMembers = riak_core_ring:members(CState, [down]),
+    Next2 = [begin
+                 OwnerLeaving = lists:member(O, LeavingMembers),
+                 NextDown = lists:member(NO, DownMembers),
+                 case (OwnerLeaving and NextDown) of
+                     true ->
+                         Active = riak_core_ring:active_members(CState) -- [O],
+                         RNode = lists:nth(rand:uniform(length(Active)),
+                                           Active),
+                         {Idx, O, RNode, Mods, Status};
+                     _ ->
+                         T
+                 end
+             end || T={Idx, O, NO, Mods, Status} <- Next],
+    Next3 = [T || T={_, O, NO, _, _} <- Next2,
+                  not lists:member(O, DownMembers),
+                  not lists:member(NO, DownMembers)],
+    Next3.
+-else.
 handle_down_nodes(CState, Next) ->
     LeavingMembers = riak_core_ring:members(CState, [leaving, invalid]),
     DownMembers = riak_core_ring:members(CState, [down]),
@@ -1426,6 +1448,7 @@ handle_down_nodes(CState, Next) ->
                   not lists:member(O, DownMembers),
                   not lists:member(NO, DownMembers)],
     Next3.
+-endif.
 
 %% @private
 reassign_indices_to(Node, NewNode, Ring) ->

--- a/src/riak_core_ring.erl
+++ b/src/riak_core_ring.erl
@@ -440,21 +440,46 @@ preflist(Key, State) -> chash:successors(Key, State?CHSTATE.chring).
 
 %% @doc Return a randomly-chosen node from amongst the owners.
 -spec random_node(State :: chstate()) -> Node :: term().
+-ifdef(rand_module).
+random_node(State) ->
+    L = all_members(State),
+    lists:nth(rand:uniform(length(L)), L).
+-else.
 random_node(State) ->
     L = all_members(State),
     lists:nth(random:uniform(length(L)), L).
+-endif.
 
 %% @doc Return a partition index not owned by the node executing this function.
 %%      If this node owns all partitions, return any index.
 -spec random_other_index(State :: chstate()) -> chash:index_as_int().
+-ifdef(rand_module).
+random_other_index(State) ->
+    L = [I || {I,Owner} <- ?MODULE:all_owners(State), Owner =/= node()],
+    case L of
+        [] -> hd(my_indices(State));
+        _ -> lists:nth(rand:uniform(length(L)), L)
+    end.
+-else.
 random_other_index(State) ->
     L = [I || {I,Owner} <- ?MODULE:all_owners(State), Owner =/= node()],
     case L of
         [] -> hd(my_indices(State));
         _ -> lists:nth(random:uniform(length(L)), L)
     end.
+-endif.
 
 -spec random_other_index(State :: chstate(), Exclude :: [term()]) -> chash:index_as_int() | no_indices.
+-ifdef(rand_module).
+random_other_index(State, Exclude) when is_list(Exclude) ->
+    L = [I || {I, Owner} <- ?MODULE:all_owners(State),
+              Owner =/= node(),
+              not lists:member(I, Exclude)],
+    case L of
+        [] -> no_indices;
+        _ -> lists:nth(rand:uniform(length(L)), L)
+    end.
+-else.
 random_other_index(State, Exclude) when is_list(Exclude) ->
     L = [I || {I, Owner} <- ?MODULE:all_owners(State),
               Owner =/= node(),
@@ -463,9 +488,19 @@ random_other_index(State, Exclude) when is_list(Exclude) ->
         [] -> no_indices;
         _ -> lists:nth(random:uniform(length(L)), L)
     end.
+-endif.
 
 %% @doc Return a randomly-chosen node from amongst the owners other than this one.
 -spec random_other_node(State :: chstate()) -> Node :: term() | no_node.
+-ifdef(rand_module).
+random_other_node(State) ->
+    case lists:delete(node(), all_members(State)) of
+        [] ->
+            no_node;
+        L ->
+            lists:nth(rand:uniform(length(L)), L)
+    end.
+-else.
 random_other_node(State) ->
     case lists:delete(node(), all_members(State)) of
         [] ->
@@ -473,9 +508,19 @@ random_other_node(State) ->
         L ->
             lists:nth(random:uniform(length(L)), L)
     end.
+-endif.
 
 %% @doc Return a randomly-chosen active node other than this one.
 -spec random_other_active_node(State :: chstate()) -> Node :: term() | no_node.
+-ifdef(rand_module).
+random_other_active_node(State) ->
+    case lists:delete(node(), active_members(State)) of
+        [] ->
+            no_node;
+        L ->
+            lists:nth(rand:uniform(length(L)), L)
+    end.
+-else.
 random_other_active_node(State) ->
     case lists:delete(node(), active_members(State)) of
         [] ->
@@ -483,6 +528,7 @@ random_other_active_node(State) ->
         L ->
             lists:nth(random:uniform(length(L)), L)
     end.
+-endif.
 
 %% @doc Incorporate another node's state into our view of the Riak world.
 -spec reconcile(ExternState :: chstate(), MyState :: chstate()) ->


### PR DESCRIPTION
I get the riak_core_ng from the hex.pm, but found the random module is still being used. And I diff the riak_core_ng code with the branch 0.9.0, and they are the same. So I make the pr on the branch 0.9.0.
update the chash to version 0.1.2, and then update the lock file.