### PR TITLE
prefer crypto:strong_rand_bytes/1

### DIFF
--- a/src/riak_core_pw_auth.erl
+++ b/src/riak_core_pw_auth.erl
@@ -33,7 +33,7 @@
 hash_password(BinaryPass) when is_binary(BinaryPass) ->
     % TODO: Do something more with the salt?
     % Generate salt the simple way
-    Salt = crypto:rand_bytes(?SALT_LENGTH),
+    Salt = crypto:strong_rand_bytes(?SALT_LENGTH),
 
     % Hash the original password and store as hex
     {ok, HashedPass} = pbkdf2:pbkdf2(?HASH_FUNCTION, BinaryPass, Salt, ?HASH_ITERATIONS),


### PR DESCRIPTION
I just see the cowlib use the strong_rand_bytes/1 to replace the rand_bytes/1.
So I add the code here, see 
[Fix #39](https://github.com/ninenines/cowlib/commit/a7d5141d13c8944867c9361e544981d9954728c4)