### PR TITLE
Use correct stat name when reporting overload

### DIFF
--- a/src/riak_core_stat.erl
+++ b/src/riak_core_stat.erl
@@ -174,7 +174,7 @@ stats() ->
      {gossip_received, spiral, [], [{one, gossip_received}]},
      {rejected_handoffs, counter, [], [{value, rejected_handoffs}]},
      {handoff_timeouts, counter, [], [{value, handoff_timeouts}]},
-     {dropped_vnode_requests_total, counter, [], [{value,dropped_vnode_requests_total}]},
+     {dropped_vnode_requests, counter, [], [{value, dropped_vnode_requests_total}]},
      {converge_delay, duration, [], [{mean, converge_delay_mean},
                                      {min, converge_delay_min},
                                      {max, converge_delay_max},


### PR DESCRIPTION
The vnode proxy updates the overload counter when reporting overload:

```
handle_overload(Msg, #state{mod=Mod, index=Index}) ->
    riak_core_stat:update(dropped_vnode_requests),
    case Msg of
        ...
    end.
```

This PR corrects the name, as per https://github.com/basho/riak_core/commit/cc1fd7242bec3b96f4c174f3f008c375aefe90ec and https://github.com/project-fifo/riak_core/pull/1
