### PR TITLE
validate localhost addresses as 127.0.*.*

### DIFF
--- a/priv/riak_core.schema
+++ b/priv/riak_core.schema
@@ -364,7 +364,7 @@ end
   "can't be a local ip",
   fun(AddrString) ->
     case inet_parse:address(AddrString) of
-      {ok, {127, _, _, _}} -> false;
+      {ok, {127, 0, _, _}} -> false;
       {ok, _} -> true;
       {error, _} -> false
     end


### PR DESCRIPTION
instead of 127.\*.\*.*

it's a escape hatch to allow local dev clusters and for people that want to get into trouble knowingly